### PR TITLE
🐛 Add apk to RUN statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ CMD ["./hello"]
 ```
 FROM alpine
 
-RUN add --no-cache wget gcc musl-dev # buildkit
+RUN apk add --no-cache wget gcc musl-dev # buildkit
 
 WORKDIR /app
 
@@ -33,7 +33,7 @@ CMD ["./hello"]
 ```
 FROM alpine
 
-RUN add --no-cache wget gcc musl-dev # buildkit
+RUN apk add --no-cache wget gcc musl-dev # buildkit
 
 WORKDIR /app
 
@@ -48,7 +48,7 @@ CMD ["./hello"]
 ```
 FROM [DOCKER REGISTRY]/[DOCKER REPO]/alpine
 
-RUN add --no-cache wget gcc musl-dev # buildkit
+RUN apk add --no-cache wget gcc musl-dev # buildkit
 
 WORKDIR /app
 


### PR DESCRIPTION
Fixes issue

```
 => ERROR [2/5] RUN add --no-cache wget gcc musl-dev # buildkit                                            0.2s
------
 > [2/5] RUN add --no-cache wget gcc musl-dev # buildkit:
#5 0.220 /bin/sh: add: not found
```